### PR TITLE
Namespace modules by `ConsulConfigProvider`

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,7 +1,7 @@
 # General application configuration
 import Config
 
-config :consul_config_provider, :http_module, Client.Mojito
+config :consul_config_provider, :http_module, ConsulConfigProvider.Client.Mojito
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,3 +1,3 @@
 import Config
 
-config :consul_config_provider, :http_module, HttpMock
+config :consul_config_provider, :http_module, ConsulConfigProvider.HttpMock

--- a/lib/client/mojito.ex
+++ b/lib/client/mojito.ex
@@ -1,6 +1,6 @@
-defmodule Client.Mojito do
+defmodule ConsulConfigProvider.Client.Mojito do
   @moduledoc "Http client using mojito"
-  @behaviour Http
+  @behaviour ConsulConfigProvider.Http
   @compile {:inline, request: 1}
 
   @impl true

--- a/lib/consul_config_provider.ex
+++ b/lib/consul_config_provider.ex
@@ -14,7 +14,7 @@ defmodule ConsulConfigProvider do
     port = System.get_env("CONSUL_PORT", "8500") |> String.to_integer()
     prefix = System.get_env("CONSUL_PREFIX", prefix)
     keys_url = "http://#{host}:#{port}/v1/kv/#{prefix}?keys=true"
-    http_module = Application.get_env(:consul_config_provider, :http_module, Client.Mojito)
+    http_module = Application.get_env(:consul_config_provider, :http_module, ConsulConfigProvider.Client.Mojito)
     transformer_module = Application.get_env(:consul_config_provider, :transformer_module, nil)
 
     {:ok, body} = http_module.request(method: :get, url: keys_url, opts: [pool: false])

--- a/lib/http.ex
+++ b/lib/http.ex
@@ -1,4 +1,4 @@
-defmodule Http do
+defmodule ConsulConfigProvider.Http do
   @moduledoc "behaviour for http commands used in the application for mox and to make the http layer plugable"
 
   # the below takes any term due to the lack of a keyword_list guard

--- a/test/consul_config_provider_test.exs
+++ b/test/consul_config_provider_test.exs
@@ -33,7 +33,7 @@ defmodule ConsulConfigProviderTest do
         |> Jason.encode!()
 
 
-      expect(HttpMock, :request, 2, fn args ->
+      expect(ConsulConfigProvider.HttpMock, :request, 2, fn args ->
         url = Keyword.get(args, :url)
 
         case String.contains?(url, "?keys=true") do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,3 @@
 ExUnit.start()
 
-Mox.defmock(HttpMock, for: Http)
+Mox.defmock(ConsulConfigProvider.HttpMock, for: ConsulConfigProvider.Http)


### PR DESCRIPTION
It's pretty dangerous to release a package on Hex that includes such root module names. This namespaces them so it plays nice with folks' codebases and other hex packages.

* `Http` => `ConsulConfigProvider.Http`
* `HttpMock` => `ConsulConfigProvider.HttpMock`
* `Client.Mojito` => `ConsulConfigProvider.Client.Mojito`