### PR TITLE
Do not force compiling the request function.

### DIFF
--- a/lib/client/mojito.ex
+++ b/lib/client/mojito.ex
@@ -3,11 +3,18 @@ defmodule Client.Mojito do
   @behaviour Http
   @compile {:inline, request: 1}
 
-  @impl true
-  def request(request_opts) do
-    case Mojito.request(request_opts) do
-      {:ok, %Mojito.Response{body: body}} -> {:ok, body}
-      {:error, any} -> {:error, any}
+  if match?({:module, _}, Code.ensure_compiled(Mojito)) do
+    @impl true
+    def request(request_opts) do
+      case Mojito.request(request_opts) do
+        {:ok, %Mojito.Response{body: body}} -> {:ok, body}
+        {:error, any} -> {:error, any}
+      end
+    end
+  else
+    @impl true
+    def request(_request_opts) do
+      {:error, :mojito_not_compiled}
     end
   end
 end


### PR DESCRIPTION
This was making Mojito an an explicit dependency upon compiling, unfortunately if Mojito does not exist, then this just explodes on trying to expand the Mojito response struct.